### PR TITLE
fix: unix sockets

### DIFF
--- a/FrameStreamInput.go
+++ b/FrameStreamInput.go
@@ -27,10 +27,11 @@ type FrameStreamInput struct {
     decoder     *framestream.Decoder
 }
 
-func NewFrameStreamInput(r io.Reader) (input *FrameStreamInput, err error) {
+func NewFrameStreamInput(r io.ReadWriter, bi bool) (input *FrameStreamInput, err error) {
     input = new(FrameStreamInput)
     decoderOptions := framestream.DecoderOptions{
         ContentType: FSContentType,
+        Bidirectional: bi,
     }
     input.decoder, err = framestream.NewDecoder(r, &decoderOptions)
     if err != nil {
@@ -45,7 +46,7 @@ func NewFrameStreamInputFromFilename(fname string) (input *FrameStreamInput, err
     if err != nil {
         return nil, err
     }
-    input, err = NewFrameStreamInput(file)
+    input, err = NewFrameStreamInput(file, false)
     return
 }
 

--- a/FrameStreamSockInput.go
+++ b/FrameStreamSockInput.go
@@ -47,7 +47,7 @@ func (input *FrameStreamSockInput) ReadInto(output chan []byte) {
             log.Printf("net.Listener.Accept() failed: %s\n", err)
             continue
         }
-        i, err := NewFrameStreamInput(conn)
+        i, err := NewFrameStreamInput(conn, true)
         if err != nil {
             log.Printf("dnstap.NewFrameStreamInput() failed: %s\n", err)
             continue

--- a/TextOutput.go
+++ b/TextOutput.go
@@ -21,7 +21,7 @@ import "io"
 import "log"
 import "os"
 
-import "code.google.com/p/goprotobuf/proto"
+import "github.com/golang/protobuf/proto"
 
 type TextFormatFunc func(*Dnstap) ([]byte, bool)
 

--- a/dnstap.pb.go
+++ b/dnstap.pb.go
@@ -14,7 +14,7 @@ It has these top-level messages:
 */
 package dnstap
 
-import proto "code.google.com/p/goprotobuf/proto"
+import proto "github.com/golang/protobuf/proto"
 import json "encoding/json"
 import math "math"
 

--- a/dnstap/main.go
+++ b/dnstap/main.go
@@ -27,7 +27,7 @@ import dnstap "github.com/dnstap/golang-dnstap"
 
 var (
     flagReadFile    = flag.String("r", "", "read dnstap payloads from file")
-    //flagReadSock    = flag.String("u", "", "read dnstap payloads from unix socket")
+    flagReadSock    = flag.String("u", "", "read dnstap payloads from unix socket")
     flagWriteFile   = flag.String("w", "-", "write output to file")
     flagQuietText   = flag.Bool("q", false, "use quiet text output")
     flagYamlText    = flag.Bool("y", false, "use verbose YAML output")
@@ -64,23 +64,22 @@ func main() {
 
     // Handle command-line arguments.
     flag.Parse()
-    /*
+    
     if *flagReadFile == "" && *flagReadSock == "" {
         fmt.Fprintf(os.Stderr, "dnstap: Error: no inputs specified.\n")
         os.Exit(1)
     }
-    */
+    
     if *flagWriteFile == "-" {
         if *flagQuietText == false && *flagYamlText == false {
             *flagQuietText = true
         }
     }
-    /*
+    
     if *flagReadFile != "" && *flagReadSock != "" {
         fmt.Fprintf(os.Stderr, "dnstap: Error: specify exactly one of -r or -u.\n")
         os.Exit(1)
     }
-    */
 
     // Open the output and start the output loop.
     if *flagQuietText {
@@ -114,7 +113,7 @@ func main() {
             os.Exit(1)
         }
         fmt.Fprintf(os.Stderr, "dnstap: opened input file %s\n", *flagReadFile)
-    } /* else if *flagReadSock != "" {
+    } else if *flagReadSock != "" {
         i, err = dnstap.NewFrameStreamSockInputFromPath(*flagReadSock)
         if err != nil {
             fmt.Fprintf(os.Stderr, "dnstap: Failed to open input socket: %s\n", err)
@@ -122,7 +121,6 @@ func main() {
         }
         fmt.Fprintf(os.Stderr, "dnstap: opened input socket %s\n", *flagReadSock)
     }
-    */
     go i.ReadInto(o.GetOutputChannel())
 
     // Wait for input loop to finish.


### PR DESCRIPTION
Made a pull request for `golang-framestream` to support `fstrm` `0.2.0` protocol - https://github.com/farsightsec/golang-framestream/pull/2. Therefore, _unix socket_ feature can be re-enabled. While here, updated dependency resolution, also. Battle-tested with Knot 2.1.1.
