### PR TITLE
Handle SIGHUP signal, reopening text format outputs to allow logrotation

### DIFF
--- a/FrameStreamOutput.go
+++ b/FrameStreamOutput.go
@@ -70,3 +70,7 @@ func (o *FrameStreamOutput) Close() {
     o.enc.Flush()
     o.enc.Close()
 }
+
+func (o *FrameStreamOutput) Reopen() {
+    return
+}

--- a/dnstap.go
+++ b/dnstap.go
@@ -29,4 +29,5 @@ type Output interface {
     GetOutputChannel() chan []byte
     RunOutputLoop()
     Close()
+    Reopen()
 }


### PR DESCRIPTION
This allows for better support of rotating text format `dnstap` output files with something like `logrotate`.

With these changes you can have a `logrotate` configuration file like this:

`/etc/logrotate.d/dnstap`:
```
/var/run/unbound/dnstap.out {
  compress
  hourly
  rotate 7
  postrotate
      # Begin writing to new file
      /usr/bin/killall -HUP dnstap
  endscript
}
```

This will move the `dnstap.out` file to a file named `dnstap.out.1`, send a `SIGHUP` to the `dnstap` process causing it to stop writing to `dnstap.out.1` and start writing to a new `dnstap.out` file instead, without missing any input. In this configuration `logrotate` will then compress the file with gzip.

This works when outputting to YAML or quiet text, the FrameStreamOutput is unchanged, aside from `dnstap` no longer exiting when it receives a `SIGHUP`. I'm not sure if there's a use case for doing this with FrameStreamOutput, but it could be added there as well if so.
