### PR TITLE
Fixes main() dnstap.Output close nil panic

### DIFF
--- a/dnstap/main.go
+++ b/dnstap/main.go
@@ -105,7 +105,6 @@ func outputLoop(opener func() dnstap.Output, data <-chan []byte) {
 func main() {
     var err error
     var i dnstap.Input
-    var o dnstap.Output
 
     runtime.GOMAXPROCS(runtime.NumCPU())
     log.SetFlags(0)
@@ -154,7 +153,4 @@ func main() {
 
     // Wait for input loop to finish.
     i.Wait()
-
-    // Shut down the output loop.
-    o.Close()
 }


### PR DESCRIPTION
In 8df42ac7728772ec76d8f569d65e1cfa4dfa938b the `dnstap.Output` handling
was reworked to allow reopening the output on SIGHUP. In the process
a nil panic was introduced in `main()`:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x20 pc=0x5b1b6f]

goroutine 1 [running]:
main.main()
>-/go/src/github.com/dnstap/golang-dnstap/dnstap/main.go:159 +0x1ef
	exit status 2
```

The root cause is on L159 where the main function tries to call
`o.Close()` while `o` is nil.

This commit removes both the unused `o` variable from `main()` as well
as the `o.Close()` that triggers the nil panic. There is no resource
being leaked since the SIGHUP rework defers a `Close()` in
`outputLoop()`.