### PR TITLE
Use `gofmt` across codebase

### DIFF
--- a/FrameStreamInput.go
+++ b/FrameStreamInput.go
@@ -23,49 +23,49 @@ import "os"
 import framestream "github.com/farsightsec/golang-framestream"
 
 type FrameStreamInput struct {
-    wait        chan bool
-    decoder     *framestream.Decoder
+	wait    chan bool
+	decoder *framestream.Decoder
 }
 
 func NewFrameStreamInput(r io.ReadWriter, bi bool) (input *FrameStreamInput, err error) {
-    input = new(FrameStreamInput)
-    decoderOptions := framestream.DecoderOptions{
-        ContentType: FSContentType,
-        Bidirectional: bi,
-    }
-    input.decoder, err = framestream.NewDecoder(r, &decoderOptions)
-    if err != nil {
-        return
-    }
-    input.wait = make(chan bool)
-    return
+	input = new(FrameStreamInput)
+	decoderOptions := framestream.DecoderOptions{
+		ContentType:   FSContentType,
+		Bidirectional: bi,
+	}
+	input.decoder, err = framestream.NewDecoder(r, &decoderOptions)
+	if err != nil {
+		return
+	}
+	input.wait = make(chan bool)
+	return
 }
 
 func NewFrameStreamInputFromFilename(fname string) (input *FrameStreamInput, err error) {
-    file, err := os.Open(fname)
-    if err != nil {
-        return nil, err
-    }
-    input, err = NewFrameStreamInput(file, false)
-    return
+	file, err := os.Open(fname)
+	if err != nil {
+		return nil, err
+	}
+	input, err = NewFrameStreamInput(file, false)
+	return
 }
 
 func (input *FrameStreamInput) ReadInto(output chan []byte) {
-    for {
-        buf, err := input.decoder.Decode()
-        if err != nil {
-            if err != io.EOF {
-                log.Printf("framestream.Decoder.Decode() failed: %s\n", err)
-            }
-            break
-        }
-        newbuf := make([]byte, len(buf))
-        copy(newbuf, buf)
-        output <- newbuf
-    }
-    close(input.wait)
+	for {
+		buf, err := input.decoder.Decode()
+		if err != nil {
+			if err != io.EOF {
+				log.Printf("framestream.Decoder.Decode() failed: %s\n", err)
+			}
+			break
+		}
+		newbuf := make([]byte, len(buf))
+		copy(newbuf, buf)
+		output <- newbuf
+	}
+	close(input.wait)
 }
 
 func (input *FrameStreamInput) Wait() {
-    <-input.wait
+	<-input.wait
 }

--- a/FrameStreamOutput.go
+++ b/FrameStreamOutput.go
@@ -23,50 +23,50 @@ import "os"
 import framestream "github.com/farsightsec/golang-framestream"
 
 type FrameStreamOutput struct {
-    outputChannel   chan []byte
-    wait            chan bool
-    enc             *framestream.Encoder
+	outputChannel chan []byte
+	wait          chan bool
+	enc           *framestream.Encoder
 }
 
 func NewFrameStreamOutput(w io.Writer) (o *FrameStreamOutput, err error) {
-    o = new(FrameStreamOutput)
-    o.outputChannel = make(chan []byte, outputChannelSize)
-    o.enc, err = framestream.NewEncoder(w, &framestream.EncoderOptions{ContentType: FSContentType})
-    if err != nil {
-        return
-    }
-    o.wait = make(chan bool)
-    return
+	o = new(FrameStreamOutput)
+	o.outputChannel = make(chan []byte, outputChannelSize)
+	o.enc, err = framestream.NewEncoder(w, &framestream.EncoderOptions{ContentType: FSContentType})
+	if err != nil {
+		return
+	}
+	o.wait = make(chan bool)
+	return
 }
 
 func NewFrameStreamOutputFromFilename(fname string) (o *FrameStreamOutput, err error) {
-    if fname == "" || fname == "-" {
-        return NewFrameStreamOutput(os.Stdout)
-    }
-    w, err := os.Create(fname)
-    if err != nil {
-        return
-    }
-    return NewFrameStreamOutput(w)
+	if fname == "" || fname == "-" {
+		return NewFrameStreamOutput(os.Stdout)
+	}
+	w, err := os.Create(fname)
+	if err != nil {
+		return
+	}
+	return NewFrameStreamOutput(w)
 }
 
-func (o *FrameStreamOutput) GetOutputChannel() (chan []byte) {
-    return o.outputChannel
+func (o *FrameStreamOutput) GetOutputChannel() chan []byte {
+	return o.outputChannel
 }
 
 func (o *FrameStreamOutput) RunOutputLoop() {
-    for frame := range o.outputChannel {
-        if _, err := o.enc.Write(frame); err != nil {
-            log.Fatalf("framestream.Encoder.Write() failed: %s\n", err)
-            break
-        }
-    }
-    close(o.wait)
+	for frame := range o.outputChannel {
+		if _, err := o.enc.Write(frame); err != nil {
+			log.Fatalf("framestream.Encoder.Write() failed: %s\n", err)
+			break
+		}
+	}
+	close(o.wait)
 }
 
 func (o *FrameStreamOutput) Close() {
-    close(o.outputChannel)
-    <-o.wait
-    o.enc.Flush()
-    o.enc.Close()
+	close(o.outputChannel)
+	<-o.wait
+	o.enc.Flush()
+	o.enc.Close()
 }

--- a/FrameStreamSockInput.go
+++ b/FrameStreamSockInput.go
@@ -21,42 +21,42 @@ import "net"
 import "os"
 
 type FrameStreamSockInput struct {
-    wait        chan bool
-    listener    net.Listener
+	wait     chan bool
+	listener net.Listener
 }
 
 func NewFrameStreamSockInput(listener net.Listener) (input *FrameStreamSockInput) {
-    input = new(FrameStreamSockInput)
-    input.listener = listener
-    return
+	input = new(FrameStreamSockInput)
+	input.listener = listener
+	return
 }
 
 func NewFrameStreamSockInputFromPath(socketPath string) (input *FrameStreamSockInput, err error) {
-    os.Remove(socketPath)
-    listener, err := net.Listen("unix", socketPath)
-    if err != nil {
-        return
-    }
-    return NewFrameStreamSockInput(listener), nil
+	os.Remove(socketPath)
+	listener, err := net.Listen("unix", socketPath)
+	if err != nil {
+		return
+	}
+	return NewFrameStreamSockInput(listener), nil
 }
 
 func (input *FrameStreamSockInput) ReadInto(output chan []byte) {
-    for {
-        conn, err := input.listener.Accept()
-        if err != nil {
-            log.Printf("net.Listener.Accept() failed: %s\n", err)
-            continue
-        }
-        i, err := NewFrameStreamInput(conn, true)
-        if err != nil {
-            log.Printf("dnstap.NewFrameStreamInput() failed: %s\n", err)
-            continue
-        }
-        log.Printf("dnstap.FrameStreamSockInput: accepted a socket connection\n")
-        go i.ReadInto(output)
-    }
+	for {
+		conn, err := input.listener.Accept()
+		if err != nil {
+			log.Printf("net.Listener.Accept() failed: %s\n", err)
+			continue
+		}
+		i, err := NewFrameStreamInput(conn, true)
+		if err != nil {
+			log.Printf("dnstap.NewFrameStreamInput() failed: %s\n", err)
+			continue
+		}
+		log.Printf("dnstap.FrameStreamSockInput: accepted a socket connection\n")
+		go i.ReadInto(output)
+	}
 }
 
 func (input *FrameStreamSockInput) Wait() {
-    select {}
+	select {}
 }

--- a/QuietTextFormat.go
+++ b/QuietTextFormat.go
@@ -27,138 +27,144 @@ import "github.com/miekg/dns"
 const quietTimeFormat = "15:04:05"
 
 func textConvertTime(s *bytes.Buffer, secs *uint64, nsecs *uint32) {
-    if secs != nil {
-        s.WriteString(time.Unix(int64(*secs), 0).Format(quietTimeFormat))
-    } else {
-        s.WriteString("??:??:??")
-    }
-    if nsecs != nil {
-        s.WriteString(fmt.Sprintf(".%06d", *nsecs / 1000))
-    } else {
-        s.WriteString(".??????")
-    }
+	if secs != nil {
+		s.WriteString(time.Unix(int64(*secs), 0).Format(quietTimeFormat))
+	} else {
+		s.WriteString("??:??:??")
+	}
+	if nsecs != nil {
+		s.WriteString(fmt.Sprintf(".%06d", *nsecs/1000))
+	} else {
+		s.WriteString(".??????")
+	}
 }
 
 func textConvertIP(s *bytes.Buffer, ip []byte) {
-    if ip != nil {
-        s.WriteString(net.IP(ip).String())
-    } else {
-        s.WriteString("MISSING_ADDRESS")
-    }
+	if ip != nil {
+		s.WriteString(net.IP(ip).String())
+	} else {
+		s.WriteString("MISSING_ADDRESS")
+	}
 }
 
 func textConvertMessage(m *Message, s *bytes.Buffer) {
-    isQuery := false
-    printQueryAddress := false
+	isQuery := false
+	printQueryAddress := false
 
-    switch *m.Type {
-    case Message_CLIENT_QUERY,
-         Message_RESOLVER_QUERY,
-         Message_AUTH_QUERY,
-         Message_FORWARDER_QUERY,
-         Message_TOOL_QUERY:
-            isQuery = true
-    case Message_CLIENT_RESPONSE,
-         Message_RESOLVER_RESPONSE,
-         Message_AUTH_RESPONSE,
-         Message_FORWARDER_RESPONSE,
-         Message_TOOL_RESPONSE:
-            isQuery = false
-    default:
-            s.WriteString("[unhandled Message.Type]\n")
-            return
-    }
+	switch *m.Type {
+	case Message_CLIENT_QUERY,
+		Message_RESOLVER_QUERY,
+		Message_AUTH_QUERY,
+		Message_FORWARDER_QUERY,
+		Message_TOOL_QUERY:
+		isQuery = true
+	case Message_CLIENT_RESPONSE,
+		Message_RESOLVER_RESPONSE,
+		Message_AUTH_RESPONSE,
+		Message_FORWARDER_RESPONSE,
+		Message_TOOL_RESPONSE:
+		isQuery = false
+	default:
+		s.WriteString("[unhandled Message.Type]\n")
+		return
+	}
 
-    if isQuery {
-        textConvertTime(s, m.QueryTimeSec, m.QueryTimeNsec)
-    } else {
-        textConvertTime(s, m.ResponseTimeSec, m.ResponseTimeNsec)
-    }
-    s.WriteString(" ")
+	if isQuery {
+		textConvertTime(s, m.QueryTimeSec, m.QueryTimeNsec)
+	} else {
+		textConvertTime(s, m.ResponseTimeSec, m.ResponseTimeNsec)
+	}
+	s.WriteString(" ")
 
-    switch *m.Type {
-    case Message_CLIENT_QUERY,
-         Message_CLIENT_RESPONSE: {
-            s.WriteString("C")
-         }
-    case Message_RESOLVER_QUERY,
-         Message_RESOLVER_RESPONSE: {
-             s.WriteString("R")
-         }
-    case Message_AUTH_QUERY,
-         Message_AUTH_RESPONSE: {
-             s.WriteString("A")
-         }
-    case Message_FORWARDER_QUERY,
-         Message_FORWARDER_RESPONSE: {
-             s.WriteString("F")
-         }
-    case Message_STUB_QUERY,
-         Message_STUB_RESPONSE: {
-             s.WriteString("S")
-         }
-    case Message_TOOL_QUERY,
-         Message_TOOL_RESPONSE: {
-             s.WriteString("T")
-         }
-    }
+	switch *m.Type {
+	case Message_CLIENT_QUERY,
+		Message_CLIENT_RESPONSE:
+		{
+			s.WriteString("C")
+		}
+	case Message_RESOLVER_QUERY,
+		Message_RESOLVER_RESPONSE:
+		{
+			s.WriteString("R")
+		}
+	case Message_AUTH_QUERY,
+		Message_AUTH_RESPONSE:
+		{
+			s.WriteString("A")
+		}
+	case Message_FORWARDER_QUERY,
+		Message_FORWARDER_RESPONSE:
+		{
+			s.WriteString("F")
+		}
+	case Message_STUB_QUERY,
+		Message_STUB_RESPONSE:
+		{
+			s.WriteString("S")
+		}
+	case Message_TOOL_QUERY,
+		Message_TOOL_RESPONSE:
+		{
+			s.WriteString("T")
+		}
+	}
 
-    if isQuery {
-        s.WriteString("Q ")
-    } else {
-        s.WriteString("R ")
-    }
+	if isQuery {
+		s.WriteString("Q ")
+	} else {
+		s.WriteString("R ")
+	}
 
-    switch *m.Type {
-    case Message_CLIENT_QUERY,
-         Message_CLIENT_RESPONSE,
-         Message_AUTH_QUERY,
-         Message_AUTH_RESPONSE:
-            printQueryAddress = true
-    }
+	switch *m.Type {
+	case Message_CLIENT_QUERY,
+		Message_CLIENT_RESPONSE,
+		Message_AUTH_QUERY,
+		Message_AUTH_RESPONSE:
+		printQueryAddress = true
+	}
 
-    if printQueryAddress {
-        textConvertIP(s, m.QueryAddress)
-    } else {
-        textConvertIP(s, m.ResponseAddress)
-    }
-    s.WriteString(" ")
+	if printQueryAddress {
+		textConvertIP(s, m.QueryAddress)
+	} else {
+		textConvertIP(s, m.ResponseAddress)
+	}
+	s.WriteString(" ")
 
-    if m.SocketProtocol != nil {
-        s.WriteString(m.SocketProtocol.String())
-    }
-    s.WriteString(" ")
+	if m.SocketProtocol != nil {
+		s.WriteString(m.SocketProtocol.String())
+	}
+	s.WriteString(" ")
 
-    var err error
-    msg := new(dns.Msg)
-    if isQuery {
-        s.WriteString(strconv.Itoa(len(m.QueryMessage)))
-        s.WriteString("b ")
-        err = msg.Unpack(m.QueryMessage)
-    } else {
-        s.WriteString(strconv.Itoa(len(m.ResponseMessage)))
-        s.WriteString("b ")
-        err = msg.Unpack(m.ResponseMessage)
-    }
+	var err error
+	msg := new(dns.Msg)
+	if isQuery {
+		s.WriteString(strconv.Itoa(len(m.QueryMessage)))
+		s.WriteString("b ")
+		err = msg.Unpack(m.QueryMessage)
+	} else {
+		s.WriteString(strconv.Itoa(len(m.ResponseMessage)))
+		s.WriteString("b ")
+		err = msg.Unpack(m.ResponseMessage)
+	}
 
-    if err != nil {
-        s.WriteString("X ")
-    } else {
-        s.WriteString("\"" + msg.Question[0].Name + "\" ")
-        s.WriteString(dns.Class(msg.Question[0].Qclass).String() + " ")
-        s.WriteString(dns.Type(msg.Question[0].Qtype).String())
-    }
+	if err != nil {
+		s.WriteString("X ")
+	} else {
+		s.WriteString("\"" + msg.Question[0].Name + "\" ")
+		s.WriteString(dns.Class(msg.Question[0].Qclass).String() + " ")
+		s.WriteString(dns.Type(msg.Question[0].Qtype).String())
+	}
 
-    s.WriteString("\n")
+	s.WriteString("\n")
 }
 
 func TextFormat(dt *Dnstap) (out []byte, ok bool) {
-    var s bytes.Buffer
+	var s bytes.Buffer
 
-    if *dt.Type == Dnstap_MESSAGE {
-        textConvertMessage(dt.Message, &s)
-        return s.Bytes(), true
-    }
+	if *dt.Type == Dnstap_MESSAGE {
+		textConvertMessage(dt.Message, &s)
+		return s.Bytes(), true
+	}
 
-    return nil, false
+	return nil, false
 }

--- a/YamlFormat.go
+++ b/YamlFormat.go
@@ -28,87 +28,87 @@ import "github.com/miekg/dns"
 const yamlTimeFormat = "2006-01-02 15:04:05.999999999"
 
 func yamlConvertMessage(m *Message, s *bytes.Buffer) {
-    s.WriteString(fmt.Sprint("  type: ", m.Type, "\n"))
+	s.WriteString(fmt.Sprint("  type: ", m.Type, "\n"))
 
-    if m.QueryTimeSec != nil && m.QueryTimeNsec != nil {
-        t := time.Unix(int64(*m.QueryTimeSec), int64(*m.QueryTimeNsec)).UTC()
-        s.WriteString(fmt.Sprint("  query_time: !!timestamp ", t.Format(yamlTimeFormat), "\n"))
-    }
+	if m.QueryTimeSec != nil && m.QueryTimeNsec != nil {
+		t := time.Unix(int64(*m.QueryTimeSec), int64(*m.QueryTimeNsec)).UTC()
+		s.WriteString(fmt.Sprint("  query_time: !!timestamp ", t.Format(yamlTimeFormat), "\n"))
+	}
 
-    if m.ResponseTimeSec != nil && m.ResponseTimeNsec != nil {
-        t := time.Unix(int64(*m.ResponseTimeSec), int64(*m.ResponseTimeNsec)).UTC()
-        s.WriteString(fmt.Sprint("  response_time: !!timestamp ", t.Format(yamlTimeFormat), "\n"))
-    }
+	if m.ResponseTimeSec != nil && m.ResponseTimeNsec != nil {
+		t := time.Unix(int64(*m.ResponseTimeSec), int64(*m.ResponseTimeNsec)).UTC()
+		s.WriteString(fmt.Sprint("  response_time: !!timestamp ", t.Format(yamlTimeFormat), "\n"))
+	}
 
-    if m.SocketFamily != nil {
-        s.WriteString(fmt.Sprint("  socket_family: ", m.SocketFamily, "\n"))
-    }
+	if m.SocketFamily != nil {
+		s.WriteString(fmt.Sprint("  socket_family: ", m.SocketFamily, "\n"))
+	}
 
-    if m.SocketProtocol != nil {
-        s.WriteString(fmt.Sprint("  socket_protocol: ", m.SocketProtocol, "\n"))
-    }
+	if m.SocketProtocol != nil {
+		s.WriteString(fmt.Sprint("  socket_protocol: ", m.SocketProtocol, "\n"))
+	}
 
-    if m.QueryAddress != nil {
-        s.WriteString(fmt.Sprint("  query_address: ", net.IP(m.QueryAddress), "\n"))
-    }
+	if m.QueryAddress != nil {
+		s.WriteString(fmt.Sprint("  query_address: ", net.IP(m.QueryAddress), "\n"))
+	}
 
-    if m.ResponseAddress != nil {
-        s.WriteString(fmt.Sprint("  response_address: ", net.IP(m.ResponseAddress), "\n"))
-    }
+	if m.ResponseAddress != nil {
+		s.WriteString(fmt.Sprint("  response_address: ", net.IP(m.ResponseAddress), "\n"))
+	}
 
-    if m.QueryPort != nil {
-        s.WriteString(fmt.Sprint("  query_port: ", *m.QueryPort, "\n"))
-    }
+	if m.QueryPort != nil {
+		s.WriteString(fmt.Sprint("  query_port: ", *m.QueryPort, "\n"))
+	}
 
-    if m.ResponsePort != nil {
-        s.WriteString(fmt.Sprint("  response_port: ", *m.ResponsePort, "\n"))
-    }
+	if m.ResponsePort != nil {
+		s.WriteString(fmt.Sprint("  response_port: ", *m.ResponsePort, "\n"))
+	}
 
-    if m.QueryZone != nil {
-        name, _, err := dns.UnpackDomainName(m.QueryZone, 0)
-        if err != nil {
-            s.WriteString("  # query_zone: parse failed\n")
-        } else {
-            s.WriteString(fmt.Sprint("  query_zone: ", strconv.Quote(name), "\n"))
-        }
-    }
+	if m.QueryZone != nil {
+		name, _, err := dns.UnpackDomainName(m.QueryZone, 0)
+		if err != nil {
+			s.WriteString("  # query_zone: parse failed\n")
+		} else {
+			s.WriteString(fmt.Sprint("  query_zone: ", strconv.Quote(name), "\n"))
+		}
+	}
 
-    if m.QueryMessage != nil {
-        msg := new(dns.Msg)
-        err := msg.Unpack(m.QueryMessage)
-        if err != nil {
-            s.WriteString("  # query_message: parse failed\n")
-        } else {
-            s.WriteString("  query_message: |\n")
-            s.WriteString("    " + strings.Replace(strings.TrimSpace(msg.String()), "\n", "\n    ", -1) + "\n")
-        }
-    }
-    if m.ResponseMessage != nil {
-        msg := new(dns.Msg)
-        err := msg.Unpack(m.ResponseMessage)
-        if err != nil {
-            s.WriteString(fmt.Sprint("  # response_message: parse failed: ", err, "\n"))
-        } else {
-            s.WriteString("  response_message: |\n")
-            s.WriteString("    " + strings.Replace(strings.TrimSpace(msg.String()), "\n", "\n    ", -1) + "\n")
-        }
-    }
-    s.WriteString("---\n")
+	if m.QueryMessage != nil {
+		msg := new(dns.Msg)
+		err := msg.Unpack(m.QueryMessage)
+		if err != nil {
+			s.WriteString("  # query_message: parse failed\n")
+		} else {
+			s.WriteString("  query_message: |\n")
+			s.WriteString("    " + strings.Replace(strings.TrimSpace(msg.String()), "\n", "\n    ", -1) + "\n")
+		}
+	}
+	if m.ResponseMessage != nil {
+		msg := new(dns.Msg)
+		err := msg.Unpack(m.ResponseMessage)
+		if err != nil {
+			s.WriteString(fmt.Sprint("  # response_message: parse failed: ", err, "\n"))
+		} else {
+			s.WriteString("  response_message: |\n")
+			s.WriteString("    " + strings.Replace(strings.TrimSpace(msg.String()), "\n", "\n    ", -1) + "\n")
+		}
+	}
+	s.WriteString("---\n")
 }
 
 func YamlFormat(dt *Dnstap) (out []byte, ok bool) {
-    var s bytes.Buffer
+	var s bytes.Buffer
 
-    s.WriteString(fmt.Sprint("type: ", dt.Type, "\n"))
-    if dt.Identity != nil {
-        s.WriteString(fmt.Sprint("identity: ", strconv.Quote(string(dt.Identity)), "\n"))
-    }
-    if dt.Version != nil {
-        s.WriteString(fmt.Sprint("version: ", strconv.Quote(string(dt.Version)), "\n"))
-    }
-    if *dt.Type == Dnstap_MESSAGE {
-        s.WriteString("message:\n")
-        yamlConvertMessage(dt.Message, &s)
-    }
-    return s.Bytes(), true
+	s.WriteString(fmt.Sprint("type: ", dt.Type, "\n"))
+	if dt.Identity != nil {
+		s.WriteString(fmt.Sprint("identity: ", strconv.Quote(string(dt.Identity)), "\n"))
+	}
+	if dt.Version != nil {
+		s.WriteString(fmt.Sprint("version: ", strconv.Quote(string(dt.Version)), "\n"))
+	}
+	if *dt.Type == Dnstap_MESSAGE {
+		s.WriteString("message:\n")
+		yamlConvertMessage(dt.Message, &s)
+	}
+	return s.Bytes(), true
 }

--- a/dnstap.go
+++ b/dnstap.go
@@ -21,12 +21,12 @@ const outputChannelSize = 32
 var FSContentType = []byte("protobuf:dnstap.Dnstap")
 
 type Input interface {
-    ReadInto(chan []byte)
-    Wait()
+	ReadInto(chan []byte)
+	Wait()
 }
 
 type Output interface {
-    GetOutputChannel() chan []byte
-    RunOutputLoop()
-    Close()
+	GetOutputChannel() chan []byte
+	RunOutputLoop()
+	Close()
 }


### PR DESCRIPTION
Not looking to fight any style wars so please close this without thought if consensus is to avoid `gofmt` :-)

This PR follows the Go community convention of [using go-fmt to format code mechanically](https://blog.golang.org/go-fmt-your-code).  It runs the following files through `gofmt -s`:
* FrameStreamInput.go
* FrameStreamOutput.go
* FrameStreamSockInput.go
* QuietTextFormat.go
* TextOutput.go
* YamlFormat.go
* dnstap.go
* dnstap/main.go