### PR TITLE
Add append output mode

### DIFF
--- a/TextOutput.go
+++ b/TextOutput.go
@@ -43,11 +43,16 @@ func NewTextOutput(writer io.Writer, format TextFormatFunc) (o *TextOutput) {
 	return
 }
 
-func NewTextOutputFromFilename(fname string, format TextFormatFunc) (o *TextOutput, err error) {
+func NewTextOutputFromFilename(fname string, format TextFormatFunc, append bool) (o *TextOutput, err error) {
 	if fname == "" || fname == "-" {
 		return NewTextOutput(os.Stdout, format), nil
 	}
-	writer, err := os.Create(fname)
+	var writer io.Writer
+	if append {
+		writer, err = os.OpenFile(fname, os.O_RDWR|os.O_CREATE|os.O_APPEND, 0644)
+	} else {
+		writer, err = os.Create(fname)
+	}
 	if err != nil {
 		return
 	}

--- a/dnstap/main.go
+++ b/dnstap/main.go
@@ -130,6 +130,13 @@ func main() {
 		}
 	}
 
+	if *flagAppendFile == true {
+		if *flagWriteFile == "-" || *flagWriteFile == "" {
+			fmt.Fprintf(os.Stderr, "dnstap: Error: -a must specify the file output path.\n")
+			os.Exit(1)
+		}
+	}
+
 	if *flagReadFile != "" && *flagReadSock != "" && *flagReadTcp != "" {
 		fmt.Fprintf(os.Stderr, "dnstap: Error: specify exactly one of -r, -u or -l.\n")
 		os.Exit(1)

--- a/dnstap/main.go
+++ b/dnstap/main.go
@@ -34,7 +34,7 @@ var (
 	flagReadFile   = flag.String("r", "", "read dnstap payloads from file")
 	flagReadSock   = flag.String("u", "", "read dnstap payloads from unix socket")
 	flagWriteFile  = flag.String("w", "-", "write output to file")
-	flagAppendFile = flag.Bool("a", false, "append to the given file, do not overwrite")
+	flagAppendFile = flag.Bool("a", false, "append to the given file, do not overwrite. valid only when outputting a text or YAML file.")
 	flagQuietText  = flag.Bool("q", false, "use quiet text output")
 	flagYamlText   = flag.Bool("y", false, "use verbose YAML output")
 )


### PR DESCRIPTION
Can restart dnstap safely without destroying the log file.  
Add `tee` command like file append mode. ( Use `-a` option )

