### PR TITLE
Tcp and unix socket output

### DIFF
--- a/FrameStreamInput.go
+++ b/FrameStreamInput.go
@@ -20,6 +20,7 @@ import (
 	"io"
 	"log"
 	"os"
+	"time"
 
 	"github.com/farsightsec/golang-framestream"
 )
@@ -27,13 +28,19 @@ import (
 type FrameStreamInput struct {
 	wait    chan bool
 	decoder *framestream.Decoder
+	timeout time.Duration
 }
 
 func NewFrameStreamInput(r io.ReadWriter, bi bool) (input *FrameStreamInput, err error) {
+	return NewFrameStreamInputTimeout(r, bi, 0)
+}
+
+func NewFrameStreamInputTimeout(r io.ReadWriter, bi bool, timeout time.Duration) (input *FrameStreamInput, err error) {
 	input = new(FrameStreamInput)
 	decoderOptions := framestream.DecoderOptions{
 		ContentType:   FSContentType,
 		Bidirectional: bi,
+		Timeout:       timeout,
 	}
 	input.decoder, err = framestream.NewDecoder(r, &decoderOptions)
 	if err != nil {

--- a/FrameStreamSockInput.go
+++ b/FrameStreamSockInput.go
@@ -20,17 +20,23 @@ import (
 	"log"
 	"net"
 	"os"
+	"time"
 )
 
 type FrameStreamSockInput struct {
 	wait     chan bool
 	listener net.Listener
+	timeout  time.Duration
 }
 
 func NewFrameStreamSockInput(listener net.Listener) (input *FrameStreamSockInput) {
 	input = new(FrameStreamSockInput)
 	input.listener = listener
 	return
+}
+
+func (input *FrameStreamSockInput) SetTimeout(timeout time.Duration) {
+	input.timeout = timeout
 }
 
 func NewFrameStreamSockInputFromPath(socketPath string) (input *FrameStreamSockInput, err error) {
@@ -49,7 +55,7 @@ func (input *FrameStreamSockInput) ReadInto(output chan []byte) {
 			log.Printf("net.Listener.Accept() failed: %s\n", err)
 			continue
 		}
-		i, err := NewFrameStreamInput(conn, true)
+		i, err := NewFrameStreamInputTimeout(conn, true, input.timeout)
 		if err != nil {
 			log.Printf("dnstap.NewFrameStreamInput() failed: %s\n", err)
 			continue

--- a/FrameStreamSockOutput.go
+++ b/FrameStreamSockOutput.go
@@ -1,0 +1,134 @@
+/*
+ * Copyright (c) 2019 by Farsight Security, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dnstap
+
+import (
+	"log"
+	"net"
+	"time"
+
+	"github.com/farsightsec/golang-framestream"
+)
+
+type SockOutputConfig struct {
+	WriteTimeout  time.Duration
+	RetryInterval time.Duration
+	Dialer        *net.Dialer
+}
+
+type FrameStreamSockOutput struct {
+	outputChannel chan []byte
+	address       net.Addr
+	conf          SockOutputConfig
+	wait          chan bool
+	dialer        *net.Dialer
+}
+
+func NewFrameStreamSockOutput(address net.Addr, conf *SockOutputConfig) (o *FrameStreamSockOutput, err error) {
+	o = &FrameStreamSockOutput{
+		outputChannel: make(chan []byte, outputChannelSize),
+		address:       address,
+		wait:          make(chan bool),
+		conf: SockOutputConfig{
+			WriteTimeout:  10 * time.Second,
+			RetryInterval: 10 * time.Second,
+		},
+		dialer: &net.Dialer{
+			Timeout: 30 * time.Second,
+		},
+	}
+	if conf != nil {
+		if conf.WriteTimeout != 0 {
+			o.conf.WriteTimeout = conf.WriteTimeout
+		}
+		if conf.RetryInterval != 0 {
+			o.conf.RetryInterval = conf.RetryInterval
+		}
+		if conf.Dialer != nil {
+			o.conf.Dialer = conf.Dialer
+		}
+	}
+
+	return
+}
+
+func (o *FrameStreamSockOutput) GetOutputChannel() chan []byte {
+	return o.outputChannel
+}
+
+func (o *FrameStreamSockOutput) RunOutputLoop() {
+	var enc *framestream.Encoder
+	var c net.Conn
+	var err error
+
+	for frame := range o.outputChannel {
+		for enc == nil {
+			c, err = o.dialer.Dial(o.address.Network(), o.address.String())
+			if err != nil {
+				log.Printf("Dial failed: %v", err)
+				c = nil
+				time.Sleep(o.conf.RetryInterval)
+				continue
+			}
+			eopt := &framestream.EncoderOptions{
+				ContentType:   FSContentType,
+				Bidirectional: true,
+			}
+			c.SetWriteDeadline(time.Now().Add(o.conf.WriteTimeout))
+			c.SetReadDeadline(time.Now().Add(o.conf.WriteTimeout))
+			enc, err = framestream.NewEncoder(c, eopt)
+			if err != nil {
+				log.Printf("framestream.NewEncoder() failed: %v\n", err)
+				if c != nil {
+					c.Close()
+					c = nil
+				}
+				enc = nil
+				continue
+			}
+			c.SetReadDeadline(time.Time{})
+		}
+
+		c.SetWriteDeadline(time.Now().Add(o.conf.WriteTimeout))
+		if _, err := enc.Write(frame); err != nil {
+			log.Printf("framestream.Encoder.Write() failed: %s\n", err)
+			enc.Close()
+			enc = nil
+			c.Close()
+			c = nil
+		}
+		if err := enc.Flush(); err != nil {
+			log.Printf("framestream.Encoder.Flush() failed: %s\n", err)
+			enc.Close()
+			enc = nil
+			c.Close()
+			c = nil
+		}
+	}
+	if enc != nil {
+		c.SetWriteDeadline(time.Now().Add(o.conf.WriteTimeout))
+		c.SetReadDeadline(time.Now().Add(o.conf.WriteTimeout))
+		enc.Close()
+		c.Close()
+	}
+	close(o.wait)
+}
+
+func (o *FrameStreamSockOutput) Close() {
+	close(o.outputChannel)
+	<-o.wait
+}

--- a/dnstap/main.go
+++ b/dnstap/main.go
@@ -125,13 +125,30 @@ func main() {
 	// Handle command-line arguments.
 	flag.Parse()
 
-	if *flagReadFile == "" && *flagReadSock == "" && *flagReadTcp == "" {
+	haveInput := false
+	for _, f := range []string{*flagReadFile, *flagReadSock, *flagReadTcp} {
+		if haveInput && f != "" {
+			fmt.Fprintf(os.Stderr, "dnstap: Error: specify exactly one of -r, -u or -l.\n")
+			os.Exit(1)
+		}
+		haveInput = haveInput || f != ""
+	}
+	if !haveInput {
 		fmt.Fprintf(os.Stderr, "dnstap: Error: no inputs specified.\n")
 		os.Exit(1)
 	}
 
+	haveFormat := false
+	for _, f := range []bool{*flagQuietText, *flagYamlText, *flagJsonText} {
+		if haveFormat && f {
+			fmt.Fprintf(os.Stderr, "dnstap: Error: specify at most one of -q, -y, or -j.\n")
+			os.Exit(1)
+		}
+		haveFormat = haveFormat || f
+	}
+
 	if *flagWriteFile == "-" || *flagWriteFile == "" {
-		if *flagQuietText == false && *flagYamlText == false && *flagJsonText == false {
+		if !haveFormat {
 			*flagQuietText = true
 		}
 	}
@@ -141,15 +158,6 @@ func main() {
 			fmt.Fprintf(os.Stderr, "dnstap: Error: -a must specify the file output path.\n")
 			os.Exit(1)
 		}
-	}
-	if *flagYamlText == true && *flagJsonText == true {
-		fmt.Fprintf(os.Stderr, "dnstap: Error: specify exactly one of -y or -j.\n")
-		os.Exit(1)
-	}
-
-	if *flagReadFile != "" && *flagReadSock != "" && *flagReadTcp != "" {
-		fmt.Fprintf(os.Stderr, "dnstap: Error: specify exactly one of -r, -u or -l.\n")
-		os.Exit(1)
 	}
 
 	var output chan []byte

--- a/dnstap/main.go
+++ b/dnstap/main.go
@@ -181,12 +181,12 @@ func main() {
 			fmt.Fprintf(os.Stderr, "dnstap: Error: invalid address: %v", err)
 			os.Exit(1)
 		}
-		sockOutput, err = dnstap.NewFrameStreamSockOutput(addr,
-			&dnstap.SockOutputConfig{Timeout: *flagTimeout})
+		sockOutput, err = dnstap.NewFrameStreamSockOutput(addr)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "dnstap: Error: failed to open socket output: %v", err)
 			os.Exit(1)
 		}
+		sockOutput.SetTimeout(*flagTimeout)
 		output = sockOutput.GetOutputChannel()
 		go sockOutput.RunOutputLoop()
 		close(outDone)

--- a/dnstap/main.go
+++ b/dnstap/main.go
@@ -130,7 +130,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	if *flagWriteFile == "-" {
+	if *flagWriteFile == "-" || *flagWriteFile == "" {
 		if *flagQuietText == false && *flagYamlText == false && *flagJsonText == false {
 			*flagQuietText = true
 		}

--- a/sock_test.go
+++ b/sock_test.go
@@ -28,7 +28,7 @@ func dialAndSend(t *testing.T, network, address string) *FrameStreamSockOutput {
 	go func() {
 		o, err := NewFrameStreamSockOutput(addr, &SockOutputConfig{
 			Dialer:        &net.Dialer{Timeout: time.Second},
-			WriteTimeout:  time.Second,
+			Timeout:       time.Second,
 			RetryInterval: time.Second,
 		})
 		if err != nil {

--- a/sock_test.go
+++ b/sock_test.go
@@ -26,14 +26,14 @@ func dialAndSend(t *testing.T, network, address string) *FrameStreamSockOutput {
 	outputChan := make(chan *FrameStreamSockOutput)
 
 	go func() {
-		o, err := NewFrameStreamSockOutput(addr, &SockOutputConfig{
-			Dialer:        &net.Dialer{Timeout: time.Second},
-			Timeout:       time.Second,
-			RetryInterval: time.Second,
-		})
+		o, err := NewFrameStreamSockOutput(addr)
 		if err != nil {
 			t.Fatal(err)
 		}
+
+		o.SetDialer(&net.Dialer{Timeout: time.Second})
+		o.SetTimeout(time.Second)
+		o.SetRetryInterval(time.Second)
 
 		outputChan <- o
 	}()


### PR DESCRIPTION
Add FrameStreamSockOutput for writing dnstap to a TCP or Unix domain socket connection maintained by the output. Expose this with new "-T" (tcp output) and "-U" (unix domain socket output) options to dnstap.