### PR TITLE
Buffer sock output

### DIFF
--- a/FrameStreamSockOutput.go
+++ b/FrameStreamSockOutput.go
@@ -183,6 +183,7 @@ func (o *FrameStreamSockOutput) RunOutputLoop() {
 					log.Printf("framestream.NewEncoder() failed: %v\n", err)
 					conn.Close()
 					enc = nil
+					time.Sleep(o.retry)
 					continue
 				}
 			}
@@ -192,6 +193,7 @@ func (o *FrameStreamSockOutput) RunOutputLoop() {
 				enc.Close()
 				conn.Close()
 				enc = nil
+				time.Sleep(o.retry)
 			}
 
 		case <-conn.timer.C:
@@ -204,7 +206,7 @@ func (o *FrameStreamSockOutput) RunOutputLoop() {
 				enc.Close()
 				conn.Close()
 				enc = nil
-				continue
+				time.Sleep(o.retry)
 			}
 		}
 	}

--- a/sock_test.go
+++ b/sock_test.go
@@ -45,6 +45,7 @@ func dialAndSend(t *testing.T, network, address string) *FrameStreamSockOutput {
 	}
 
 	go out.RunOutputLoop()
+	<-time.After(500 * time.Millisecond)
 	out.GetOutputChannel() <- []byte("frame")
 	return out
 }

--- a/sock_test.go
+++ b/sock_test.go
@@ -33,6 +33,7 @@ func dialAndSend(t *testing.T, network, address string) *FrameStreamSockOutput {
 
 		o.SetDialer(&net.Dialer{Timeout: time.Second})
 		o.SetTimeout(time.Second)
+		o.SetFlushTimeout(100 * time.Millisecond)
 		o.SetRetryInterval(time.Second)
 
 		outputChan <- o

--- a/sock_test.go
+++ b/sock_test.go
@@ -22,28 +22,15 @@ func dialAndSend(t *testing.T, network, address string) *FrameStreamSockOutput {
 		t.Fatal(err)
 	}
 
-	var out *FrameStreamSockOutput
-	outputChan := make(chan *FrameStreamSockOutput)
-
-	go func() {
-		o, err := NewFrameStreamSockOutput(addr)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		o.SetDialer(&net.Dialer{Timeout: time.Second})
-		o.SetTimeout(time.Second)
-		o.SetFlushTimeout(100 * time.Millisecond)
-		o.SetRetryInterval(time.Second)
-
-		outputChan <- o
-	}()
-
-	select {
-	case out = <-outputChan:
-	case <-time.After(time.Second):
-		t.Fatal("can't create a new encoder")
+	out, err := NewFrameStreamSockOutput(addr)
+	if err != nil {
+		t.Fatal(err)
 	}
+
+	out.SetDialer(&net.Dialer{Timeout: time.Second})
+	out.SetTimeout(time.Second)
+	out.SetFlushTimeout(100 * time.Millisecond)
+	out.SetRetryInterval(time.Second)
 
 	go out.RunOutputLoop()
 	<-time.After(500 * time.Millisecond)


### PR DESCRIPTION
The initial socket output implementation flushed on every write, in part to avoid triggering timeouts due to hidden buffering. This revision adds a flush timeout to the API, and forces a buffer flush if the flush timeout has passed since the last write.