### PR TITLE
Quote IP addresses in yaml output

### DIFF
--- a/YamlFormat.go
+++ b/YamlFormat.go
@@ -51,11 +51,11 @@ func yamlConvertMessage(m *Message, s *bytes.Buffer) {
 	}
 
 	if m.QueryAddress != nil {
-		s.WriteString(fmt.Sprint("  query_address: ", net.IP(m.QueryAddress), "\n"))
+		s.WriteString(fmt.Sprint("  query_address: ", strconv.Quote(net.IP(m.QueryAddress).String()), "\n"))
 	}
 
 	if m.ResponseAddress != nil {
-		s.WriteString(fmt.Sprint("  response_address: ", net.IP(m.ResponseAddress), "\n"))
+		s.WriteString(fmt.Sprint("  response_address: ", strconv.Quote(net.IP(m.ResponseAddress).String()), "\n"))
 	}
 
 	if m.QueryPort != nil {


### PR DESCRIPTION
IPv6 addresses like `::` or `2001:500:12::` aren't valid yaml strings unless quoted. This PR quotes all IP addresses in yaml output to prevent yaml parsing errors.

**Notes:**
An alternative is to export json, which I was able to do in my case, but there may be situations where yaml is a preferred or required output format.
I followed the use of `strconf.Quote()` found throughout the file rather than embedding `\"` in the strings directly.
I haven't taken the time to check if any other fields might also need quoting since I only ran into issues with IP addresses.