### PR TITLE
Added closing support for FrameStreamSockInput

### DIFF
--- a/FrameStreamSockInput.go
+++ b/FrameStreamSockInput.go
@@ -76,43 +76,45 @@ func NewFrameStreamSockInputFromPath(socketPath string) (input *FrameStreamSockI
 
 // ReadInto accepts connections to the FrameStreamSockInput's listening
 // socket and sends all dnstap data read from these connections to the
-// output channel.
+// output channel. It blocks until `Close` is called.
 //
 // ReadInto satisfies the dnstap Input interface.
 func (input *FrameStreamSockInput) ReadInto(output chan []byte) {
 	var (
-		n     = uint64(0)
-		m     sync.Mutex // protects conns
-		conns = make(map[uint64]net.Conn)
-		wg    = &sync.WaitGroup{}
+		n     = uint64(0)                 // connection counter
+		m     sync.Mutex                  // protects conns
+		conns = make(map[uint64]net.Conn) // map of active connections
+		wg    = &sync.WaitGroup{}         // wait group for the termination
 	)
+
 	for {
 		conn, err := input.listener.Accept()
 		if err != nil {
-			input.log.Printf("%s: accept failed: %v\n",
-				input.listener.Addr(),
-				err)
+			input.log.Printf("%s: accept failed: %v\n", input.listener.Addr(), err)
 
 			if errors.Is(err, net.ErrClosed) {
+				// net.ErrClosed is returned when the listener has been closed
 				break
 			}
 
 			continue
 		}
+
 		n++
 		origin := ""
+
 		switch conn.RemoteAddr().Network() {
 		case "tcp", "tcp4", "tcp6":
 			origin = fmt.Sprintf(" from %s", conn.RemoteAddr())
 		}
+
 		i, err := NewFrameStreamInputTimeout(conn, true, input.timeout)
 		if err != nil {
-			input.log.Printf("%s: connection %d: open input%s failed: %v",
-				conn.LocalAddr(), n, origin, err)
+			input.log.Printf("%s: connection %d: open input%s failed: %v", conn.LocalAddr(), n, origin, err)
 			continue
 		}
-		input.log.Printf("%s: accepted connection %d%s",
-			conn.LocalAddr(), n, origin)
+
+		input.log.Printf("%s: accepted connection %d%s", conn.LocalAddr(), n, origin)
 		i.SetLogger(input.log)
 
 		// store the connection so we can close it later
@@ -124,10 +126,11 @@ func (input *FrameStreamSockInput) ReadInto(output chan []byte) {
 		go func(cn uint64) {
 			defer wg.Done()
 
+			// read from the connection into the output
 			i.ReadInto(output)
-			input.log.Printf("%s: closed connection %d%s",
-				conn.LocalAddr(), cn, origin)
+			input.log.Printf("%s: closed connection %d%s", conn.LocalAddr(), cn, origin)
 
+			// delete our connection from the map
 			m.Lock()
 			delete(conns, n)
 			m.Unlock()
@@ -136,8 +139,10 @@ func (input *FrameStreamSockInput) ReadInto(output chan []byte) {
 
 	// close all active connections
 	m.Lock()
+	input.log.Printf("listener has been closed, closing all %d active connections", len(conns))
+
 	for _, c := range conns {
-		_ = c.Close()
+		c.Close()
 	}
 	m.Unlock()
 
@@ -146,14 +151,18 @@ func (input *FrameStreamSockInput) ReadInto(output chan []byte) {
 	close(input.wait)
 }
 
+// Wait for the `ReadInto` method to terminate. It will block forever if you never call `ReadInto`.
+// After Wait has returned, all connections and the listener have been closed.
 // Wait satisfies the dnstap Input interface.
-//
-// The FrameSTreamSocketInput Wait method never returns, because the
-// corresponding Readinto method also never returns.
 func (input *FrameStreamSockInput) Wait() {
 	<-input.wait
 }
 
+// Close terminates the processing of incoming connections by closing the listener. It does not
+// wait for the connection handlers or `ReadInto` to stop, you can use the `Wait` method for that.
+// The output channel will not be closed automatically. `ReadInto` will return after this method
+// has been called and all workers have stopped. Don't reuse a closed instance of
+// FrameStreamSockInput.
 func (input *FrameStreamSockInput) Close() error {
 	return input.listener.Close()
 }

--- a/FrameStreamSockInput.go
+++ b/FrameStreamSockInput.go
@@ -153,3 +153,7 @@ func (input *FrameStreamSockInput) ReadInto(output chan []byte) {
 func (input *FrameStreamSockInput) Wait() {
 	<-input.wait
 }
+
+func (input *FrameStreamSockInput) Close() error {
+	return input.listener.Close()
+}


### PR DESCRIPTION
Currently the `FrameStreamSockInput` does not support being closed. Depending on the use case, this may be undesirable since it may leak go-routines. Further, a broken listener (for whatever reason) lead to a busy loop where `ReadInto` would spam "accept failed".

This PR changes the following:
- `ReadInto` now keeps track of active connections
- Closing the listener now leads to `ReadInto` returning
- Before returning, `ReadInto` will close all accepted connections
- Before returning, `ReadInto` will close the `wait` channel
- Added the `Close` method, which closes the listener
- The `Wait` method now waits for `wait` to be closed
- Added and updated comments

I'd be happy about feedback on the code or suggestions for further improvements.