### PR TITLE
Add support for the "extra" field in dnstap payload for JSON and YAML output

### DIFF
--- a/dnstap/dnstap.8
+++ b/dnstap/dnstap.8
@@ -135,6 +135,19 @@ form similar to the output of \fBdig(1)\fR.
 At most one text format (\fB-j\fR, \fB-q\fR, or \fB-y\fR) option may be given.
 
 
+.TP
+.B -x \fIformat-type\fR
+Specify output format of the 'extra' field in dnstap payload if exists.
+
+Available options for \fIformat-type\fR includes:
+ - text (default)
+ - hex
+ - base64
+
+Valid only when the YAML or JSON format is specified with the \fB-y\fR
+or \fB-j\fR options.
+
+
 .SH EXAMPLES
 
 Listen for Dnstap data from a local name server and print quiet text format

--- a/dnstap/dnstap.8
+++ b/dnstap/dnstap.8
@@ -144,8 +144,11 @@ Available options for \fIformat-type\fR includes:
  - hex
  - base64
 
+For the default text format, if the 'extra' field in payload contains
+non-printable characters, the 'extra' text will be escaped.
+
 Valid only when the YAML or JSON format is specified with the \fB-y\fR
-or \fB-j\fR options.
+or \fB-j\fR options. (bianry output does not need a format)
 
 
 .SH EXAMPLES

--- a/dnstap/main.go
+++ b/dnstap/main.go
@@ -46,6 +46,7 @@ var (
 	flagQuietText  = flag.Bool("q", false, "use quiet text output")
 	flagYamlText   = flag.Bool("y", false, "use verbose YAML output")
 	flagJSONText   = flag.Bool("j", false, "use verbose JSON output")
+	flagExtraFmt   = flag.String("x", "", "specify the 'extra' field format in output. Available options:\n - text (default)\n - hex\n - base64\nvalid when outputting YAML or JSON.")
 )
 
 func usage() {
@@ -116,10 +117,22 @@ func main() {
 		switch {
 		case *flagYamlText:
 			format = dnstap.YamlFormat
+			switch *flagExtraFmt{
+			case "hex":
+				format = dnstap.YamlFormatWithHexExtra
+			case "base64":
+				format = dnstap.YamlFormatWithBase64Extra
+			}
 		case *flagQuietText:
 			format = dnstap.TextFormat
 		case *flagJSONText:
 			format = dnstap.JSONFormat
+			switch *flagExtraFmt{
+			case "hex":
+				format = dnstap.JSONFormatWithHexExtra
+			case "base64":
+				format = dnstap.JSONFormatWithBase64Extra
+			}
 		}
 
 		o, err := newFileOutput(*flagWriteFile, format, *flagAppendFile)


### PR DESCRIPTION
Current dnstap command line tool won't output the "extra" field defined in [dnstap.proto](https://github.com/dnstap/dnstap.pb/blob/master/dnstap.proto#L40) for JSON and YAML output. This PR fixed this issue.

As no encoding is enforced for the "extra" field, I used `strconv.Quote` to escape possible non-printable characters by default. Also, hexadecimal output or base64 output is supported with the `-x` option.